### PR TITLE
Consolidate getChild() and getChild(String)

### DIFF
--- a/projects/com.ibm.itest.cloud.common/src/com/ibm/itest/cloud/common/pages/elements/BrowserElement.java
+++ b/projects/com.ibm.itest.cloud.common/src/com/ibm/itest/cloud/common/pages/elements/BrowserElement.java
@@ -18,6 +18,7 @@ import static com.ibm.itest.cloud.common.performance.PerfManager.PERFORMANCE_ENA
 import static com.ibm.itest.cloud.common.scenario.ScenarioUtils.*;
 import static com.ibm.itest.cloud.common.utils.ByUtils.fixLocator;
 import static com.ibm.itest.cloud.common.utils.ByUtils.getNormalizedLocatorString;
+import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +74,8 @@ import com.ibm.itest.cloud.common.scenario.errors.*;
 public class BrowserElement implements WebElement, Locatable {
 
 	/* Locators */
-	private static final By CHILDREN_LOCATOR = By.xpath("./child::*");
+	private static final String XPATH_NODE_WILDCARD = "*";
+	private static final String XPATH_CHILDREN_AXES = "./child::";
 
 	/* Javascripts */
 	private final static String MOUSE_OVER_JAVASCRIPT =
@@ -86,58 +88,58 @@ public class BrowserElement implements WebElement, Locatable {
 	 */
 	public static final int MAX_RECOVERY_ATTEMPTS = 5;
 
-/**
- * Return a list of {@link BrowserElement} assuming the given list *is* a
- * list of this kind of {@link WebElement}.
- *
- * @param elements The list of {@link WebElement}.
- * @return The list of {@link BrowserElement}.
- * @throws IllegalArgumentException If one of the element of the given list is
- * not a {@link BrowserElement}.
- */
-public static List<BrowserElement> getList(final List<WebElement> elements) {
-	List<BrowserElement> webElements = new ArrayList<BrowserElement>(elements.size());
-	for (WebElement element: elements) {
-		try {
-			webElements.add((BrowserElement)element);
+	/**
+	 * Return a list of {@link BrowserElement} assuming the given list *is* a
+	 * list of this kind of {@link WebElement}.
+	 *
+	 * @param elements The list of {@link WebElement}.
+	 * @return The list of {@link BrowserElement}.
+	 * @throws IllegalArgumentException If one of the element of the given list is
+	 * not a {@link BrowserElement}.
+	 */
+	public static List<BrowserElement> getList(final List<WebElement> elements) {
+		List<BrowserElement> webElements = new ArrayList<BrowserElement>(elements.size());
+		for (WebElement element: elements) {
+			try {
+				webElements.add((BrowserElement)element);
+			}
+			catch (ClassCastException cce) {
+				throw new IllegalArgumentException("The given list was not a list of WebBrowserElement: "+cce.getMessage());
+			}
 		}
-		catch (ClassCastException cce) {
-			throw new IllegalArgumentException("The given list was not a list of WebBrowserElement: "+cce.getMessage());
-		}
+		return webElements;
 	}
-	return webElements;
-}
 
-	/**
-	 * The browser to use to search the web element.
-	 */
-	final private Browser browser;
+/**
+ * The browser to use to search the web element.
+ */
+final private Browser browser;
 
-	/**
-	 * The mechanism to use to search the web element.
-	 */
-	final private By by;
+/**
+ * The mechanism to use to search the web element.
+ */
+final private By by;
 
-	/**
-	 * The context to use to search the web element.
-	 * <p>
-	 * If the search is expected to be done in the entire web document, then
-	 * it will be a {@link WebDriver} object, otherwise, ie. if the search is expected
-	 * to be done relatively to another web element, then it will be a
-	 * {@link BrowserElement}.
-	 * </p>
-	 */
-	final private SearchContext context;
+/**
+ * The context to use to search the web element.
+ * <p>
+ * If the search is expected to be done in the entire web document, then
+ * it will be a {@link WebDriver} object, otherwise, ie. if the search is expected
+ * to be done relatively to another web element, then it will be a
+ * {@link BrowserElement}.
+ * </p>
+ */
+final private SearchContext context;
 
-	/**
-	 * The wrapped selenium web element.
-	 */
-	WebElement webElement;
+/**
+ * The wrapped selenium web element.
+ */
+WebElement webElement;
 
-	/**
-	 * The frame used when searching the current web element.
-	 */
-	private BrowserFrame frame;
+/**
+ * The frame used when searching the current web element.
+ */
+private BrowserFrame frame;
 
 /**
  * Information of parent when the current web element has been found
@@ -749,15 +751,7 @@ public By getBy() {
  * for the current element.
  */
 public BrowserElement getChild() throws ScenarioFailedError{
-	List<BrowserElement> children = getChildren();
-	switch(children.size()) {
-		case 1:
-			return children.get(0);
-		case 0:
-			throw new WaitElementTimeoutError("Web element "+this+" has no child.");
-		default:
-			throw new ScenarioFailedError("Web element "+this+" has more than one child.");
-	}
+	return getSingularChild(unmodifiableList(getChildren()));
 }
 
 /**
@@ -769,15 +763,7 @@ public BrowserElement getChild() throws ScenarioFailedError{
  * for the current element.
  */
 public BrowserElement getChild(final String tag) throws ScenarioFailedError{
-	List<BrowserElement> children = getChildren(tag);
-	switch(children.size()) {
-		case 1:
-			return children.get(0);
-		case 0:
-			throw new WaitElementTimeoutError("Web element "+this+" has no child.");
-		default:
-			throw new ScenarioFailedError("Web element "+this+" has more than one child.");
-	}
+	return getSingularChild(unmodifiableList(getChildren(tag)));
 }
 
 /**
@@ -786,7 +772,7 @@ public BrowserElement getChild(final String tag) throws ScenarioFailedError{
  * @return The list of web element children as a {@link List} of {@link BrowserElement}.
  */
 public List<BrowserElement> getChildren() {
-	return getList(findElements(CHILDREN_LOCATOR));
+	return getList(findElements(By.xpath(XPATH_CHILDREN_AXES + XPATH_NODE_WILDCARD)));
 }
 
 /**
@@ -795,7 +781,7 @@ public List<BrowserElement> getChildren() {
  * @return The list of web element children as a {@link List} of {@link BrowserElement}.
  */
 public List<BrowserElement> getChildren(final String tag) {
-	return getList(findElements(By.xpath("./child::"+tag)));
+	return getList(findElements(By.xpath(XPATH_CHILDREN_AXES + tag)));
 }
 
 /**
@@ -993,6 +979,17 @@ public Rectangle getRect() {
 @Override
 public <X> X getScreenshotAs(final OutputType<X> target) throws WebDriverException {
 	return this.webElement.getScreenshotAs(target);
+}
+
+private BrowserElement getSingularChild(final List<BrowserElement> children) throws ScenarioFailedError {
+	switch(children.size()) {
+		case 1:
+			return children.get(0);
+		case 0:
+			throw new WaitElementTimeoutError("Web element " + this + " has no child.");
+		default:
+			throw new ScenarioFailedError("Web element " + this + " has more than one child.");
+	}
 }
 
 /**


### PR DESCRIPTION
- Change some coding format issues: Make static method has indentation; and instance fields no indentation.
- Consolidate getChild() and getChild(String)

Signed-off-by: Hongyin Huo <hhuo@ca.ibm.com>