### PR TITLE
Modify Javadoc of ElementWrapper.waitForElement(s)

### DIFF
--- a/projects/com.ibm.itest.cloud.common/src/com/ibm/itest/cloud/common/pages/elements/ElementWrapper.java
+++ b/projects/com.ibm.itest.cloud.common/src/com/ibm/itest/cloud/common/pages/elements/ElementWrapper.java
@@ -820,14 +820,16 @@ public BrowserElement waitForElement(final By locator, final int timeout, final 
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within the current wrapped element, using the given
+ * locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research
- * @param fail Tells whether to fail if none of the locators is find before timeout
+ * @param locator The locator to find the element in the current wrapped element. The
+ * locator must be relative to the current wrapped element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  *
@@ -842,14 +844,17 @@ public BrowserElement waitForElement(final By locator, final int timeout, final 
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within the current wrapped element, using the given
+ * locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails if specified and after having waited the given timeout, or if multiple
+ * elements are found and only single one was expected.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research
- * @param fail Tells whether to fail if none of the locators is find before timeout
+ * @param locator The locator to find the element in the current wrapped element. The
+ * locator must be relative to the current wrapped element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  * @param single Tells whether a single element is expected.
@@ -865,14 +870,16 @@ public BrowserElement waitForElement(final By locator, final int timeout, final 
 }
 
 /**
- * Waits until have found one of element using the given search locators.
+ * Waits until finding the element within the current wrapped element, using one of the
+ * given locators.
  * <p>
- * Fails only if specified and after having waited the given timeout.
+ * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
- * @param locators Search locators of the expected elements.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
+ * @param locators The locators to find the element in the current wrapped element.
+ * These locators must be relative to the current wrapped element.
  *
  * @return The web element as {@link BrowserElement} or <code>null</code>
  * if no element was found before the timeout and asked not to fail.
@@ -884,13 +891,15 @@ public BrowserElement waitForElement(final int timeout, final boolean fail, fina
 }
 
 /**
- * Waits until have found one of element using the given search locators.
+ * Waits until finding the element within the current wrapped element, using one of the
+ * given locators.
  * <p>
- * Fails only if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param timeout The time to wait before giving up the research.
- * @param locators Search locators of the expected elements.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param locators The locators to find the element in the current wrapped element.
+ * These locators must be relative to the current wrapped element.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -901,14 +910,16 @@ public BrowserElement waitForElement(final int timeout, final By... locators) {
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within a specified parent element,
+ * using the given locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
  *
  * @return A {@link List} of web element as {@link BrowserElement}.
  *
@@ -919,14 +930,16 @@ public List<BrowserElement> waitForElements(final BrowserElement parentElement, 
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within a specified parent element,
+ * using the given locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  *
@@ -939,15 +952,17 @@ public List<BrowserElement> waitForElements(final BrowserElement parentElement, 
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within a specified parent element,
+ * using the given locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
  *
  * @return A {@link List} of web element as {@link BrowserElement}.
  *
@@ -958,16 +973,18 @@ public List<BrowserElement> waitForElements(final BrowserElement parentElement, 
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within a specified parent element,
+ * using the given locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  *
  * @return A {@link List} of web element as {@link BrowserElement}. Might
  * be empty if no element was found before the timeout and asked not to fail.
@@ -980,16 +997,18 @@ public List<BrowserElement> waitForElements(final BrowserElement parentElement, 
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within a specified parent element,
+ * using the given locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  *
@@ -1004,12 +1023,14 @@ public List<BrowserElement> waitForElements(final BrowserElement parentElement, 
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within the current wrapped element,
+ * using the given locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
+ * @param locator The locators to find the element in the current wrapped element.
+ * These locators must be relative to the current wrapped element.
  *
  * @return A {@link List} of web element as {@link BrowserElement}.
  *
@@ -1020,13 +1041,15 @@ public List<BrowserElement> waitForElements(final By locator) {
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within the current wrapped element,
+ * using the given locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
+ * @param locator The locators to find the element in the current wrapped element.
+ * These locators must be relative to the current wrapped element.
+ * @param timeout The time to wait in seconds before giving up the search.
  *
  * @return A {@link List} of web element as {@link BrowserElement}.
  *
@@ -1037,14 +1060,16 @@ public List<BrowserElement> waitForElements(final By locator, final int timeout)
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within the current wrapped element,
+ * using the given locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
+ * @param locator The locators to find the element in the current wrapped element.
+ * These locators must be relative to the current wrapped element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  *
  * @return A {@link List} of web element as {@link BrowserElement}. Might
  * be empty if no element was found before the timeout and asked not to fail.
@@ -1057,14 +1082,16 @@ public List<BrowserElement> waitForElements(final By locator, final int timeout,
 }
 
 /**
- * Waits until have found one or several elements using given locator.
+ * Waits until finding one or several elements within the current wrapped element,
+ * using the given locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
+ * @param locator The locators to find the element in the current wrapped element.
+ * These locators must be relative to the current wrapped element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  *

--- a/projects/com.ibm.itest.cloud.common/src/com/ibm/itest/cloud/common/pages/elements/ElementWrapper.java
+++ b/projects/com.ibm.itest.cloud.common/src/com/ibm/itest/cloud/common/pages/elements/ElementWrapper.java
@@ -462,14 +462,15 @@ public BrowserElement typeText(final By locator, final String text, final Keys k
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within a specified parent element, using a locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locator to find the element in the specified parent element. This
+ * locator must be relative to the parent element.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -481,14 +482,16 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final B
 }
 
 /**
- * Waits until have found one of element using the given search locators.
+ * Waits until finding an element within a specified parent element, using one of the
+ * given locators.
  * <p>
- * Fails only if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locators Search locators of the expected elements.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locators The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -499,15 +502,16 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final B
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within a specified parent element, using a locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locator to find the element in the specified parent element. This
+ * locator must be relative to the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -519,16 +523,17 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final B
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within a specified parent element, using a locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locator to find the element in the specified parent element. This
+ * locator must be relative to the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  *
  * @return The web element as {@link BrowserElement} or <code>null</code>
  * if no element was found before the timeout and asked not to fail.
@@ -541,16 +546,17 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final B
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within a specified parent element, using a locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research
- * @param fail Tells whether to fail if none of the locators is find before timeout
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locator to find the element in the specified parent element. This
+ * locator must be relative to the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  *
@@ -565,16 +571,18 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final B
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within a specified parent element, using a locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails if specified and after having waited the given timeout, or if multiple
+ * elements are found and only single one was expected.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research
- * @param fail Tells whether to fail if none of the locators is find before timeout
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locator to find the element in the specified parent element. This
+ * locator must be relative to the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  * @param single Tells whether a single element is expected.
@@ -590,16 +598,19 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final B
 }
 
 /**
- * Waits until have found one of element using the given search locators.
+ * Waits until finding an element within a specified parent element, using one of the
+ * given locators.
  * <p>
- * Fails only if specified and after having waited the given timeout.
+ * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
- * @param locators Search locators of the expected elements.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if none of the elements is located before timeout.
+ * @param locators The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
+ *
  * @return The web element as {@link BrowserElement} or <code>null</code>
  * if no element was found before the timeout and asked not to fail.
  *
@@ -610,15 +621,17 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final i
 }
 
 /**
- * Waits until have found one of element using the given search locators.
+ * Waits until finding an element within a specified parent element, using one of the
+ * given locators.
  * <p>
- * Fails only if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param parentElement The element from where the search must start.
- * If <code>null</code> then element is expected in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param locators Search locators of the expected elements.
+ * @param parentElement The element where the search must start. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param locators The locators to find the element in the specified parent element.
+ * These locators must be relative to the parent element.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -629,21 +642,22 @@ public BrowserElement waitForElement(final BrowserElement parentElement, final i
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding an element within the current wrapped element, using the given
+ * locator.
  * <p>
  * Note that:
  * <ul>
  * <li>hidden element will be ignored</li>
  * <li>it will fail if:
  * <ol>
- * <li>the element is not found before timeout seconds</li>
- * <li>there's more than one element found</li>
+ * <li>the element is not found before {@link #timeout()} seconds</li>
+ * <li>there is more than one element found</li>
  * </ol></li>
  * </ul>
  * </p>
- * </p>
  *
- * @param locator Locator to find the element in the current page.
+ * @param locator The locator to find the element in the current wrapped element.
+ * The locator must be relative to the current wrapped element.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -655,12 +669,14 @@ public BrowserElement waitForElement(final By locator) {
 }
 
 /**
- * Waits until have found one of element using the given search locators.
+ * Waits until finding an element within the current wrapped element, using one of the
+ * given locators.
  * <p>
- * Fails only if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param locators Search locators of the expected elements.
+ * @param locators The locators to find the element in the current wrapped element.
+ * These locators must be relative to the current wrapped element.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -671,12 +687,14 @@ public BrowserElement waitForElement(final By... locators) {
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding an element within the current wrapped element, using the given
+ * locator.
  * <p>
- * Only fails if specified and after having waited the given timeout.
+ * Only fails after having waited the given timeout.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
+ * @param locator The locator to find the element in the current wrapped element.
+ * The locator must be relative to the current wrapped element.
  * @param displayed When <code>true</code> then only displayed element can be returned.
  * When <code>false</code> then the returned element can be either displayed or hidden.
  *
@@ -691,46 +709,52 @@ public BrowserElement waitForElement(final By locator, final boolean displayed) 
 }
 
 /**
- * Waits until have found the web element relatively to a parent element using
- * the respective given mechanisms.
+ * Waits until finding an element within a parent element, using the respective given
+ * locators.
  * <p>
  * Note that:
  * <ul>
+ * <li>hidden element will be ignored</li>
  * <li>it will fail if:
  * <ol>
  * <li>the element is not found before {@link #timeout()} seconds</li>
- * <li>there's more than one element found</li>
+ * <li>there is more than one element found</li>
  * </ol></li>
- * <li>hidden element will be ignored</li>
  * </p>
- * @param parentLocator The locator to find the parent element in the current
- * element, if <code>null</code>, the element will be searched in the current element.
- * @param locator The locator to find the element in the current page or
- * from the given parent element if not <code>null</code>
- * @return The web element as {@link BrowserElement}
+ *
+ * @param parentLocator The locator to find the parent element in the current wrapped
+ * element. The locator must be relative to the current wrapped element. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locator to find the element in the parent element. The locator must
+ * be relative to the parent element.
+ *
+ * @return The web element as {@link BrowserElement}.
+ *
  * @throws ScenarioFailedError if no element was found before the {@link #timeout()}.
  *
  * @see #waitForElement(By, By, boolean, int)
  */
 public BrowserElement waitForElement(final By parentLocator, final By locator) {
-	return waitForElement(parentLocator, locator, true/*fail*/, timeout());
+	return waitForElement(parentLocator, locator, true /*fail*/, timeout());
 }
 
 /**
- * Waits until have found the web element relatively to a parent element using
- * the respective given mechanisms.
+ * Waits until finding an element within a parent element, using the respective given
+ * locators.
  * <p>
  * Note that:
  * <ul>
  * <li>it will fail if there's more than one element found</li>
  * <li>hidden element will be ignored</li>
  * </p>
- * @param parentLocator The locator to find the parent element in the current
- * element, if <code>null</code>, the element will be searched in the current element.
- * @param locator The locator to find the element in the current page or
- * from the given parent element if not <code>null</code>.
- * @param fail Tells whether to fail if none of the elements is find before timeout.
- * @param time_out The time to wait before giving up the research.
+ *
+ * @param parentLocator The locator to find the parent element in the current wrapped
+ * element. The locator must be relative to the current wrapped element. If {@code null},
+ * the current wrapped element will be regarded as the parent element.
+ * @param locator The locator to find the element in the parent element. The locator must
+ * be relative to the parent element.
+ * @param fail Tells whether to fail if no element is located before timeout.
+ * @param timeout The time to wait in seconds before giving up the search.
  *
  * @return The web element as {@link BrowserElement} or <code>null</code>
  * if no element was found before the timeout and asked not to fail.
@@ -740,28 +764,29 @@ public BrowserElement waitForElement(final By parentLocator, final By locator) {
  *
  * @see Browser#waitForElement(BrowserElement, By, int, boolean, boolean, boolean)
  */
-public BrowserElement waitForElement(final By parentLocator, final By locator, final boolean fail, final int time_out) {
+public BrowserElement waitForElement(final By parentLocator, final By locator, final boolean fail, final int timeout) {
 	BrowserElement parentElement = (parentLocator != null) ? waitForElement(parentLocator) : this.element;
-	return this.browser.waitForElement(parentElement, locator, time_out, fail, true /*displayed*/, true /*single*/);
+	return this.browser.waitForElement(parentElement, locator, timeout, fail, true /*displayed*/, true /*single*/);
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within the current wrapped element, using the given
+ * locator.
  * <p>
  * Note that:
  * <ul>
  * <li>hidden element will be ignored</li>
  * <li>it will fail if:
  * <ol>
- * <li>the element is not found before timeout seconds</li>
- * <li>there's more than one element found</li>
+ * <li>the element is not found before {@link #timeout()} seconds</li>
+ * <li>there is more than one element found</li>
  * </ol></li>
  * </ul>
  * </p>
- * </p>
  *
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
+ * @param locator The locator to find the element in the current wrapped element. The
+ * locator must be relative to the current wrapped element.
+ * @param timeout The time to wait in seconds before giving up the search.
  *
  * @return The web element as {@link BrowserElement}.
  *
@@ -773,14 +798,16 @@ public BrowserElement waitForElement(final By locator, final int timeout) {
 }
 
 /**
- * Waits until have found the element using given locator.
+ * Waits until finding the element within the current wrapped element, using the given
+ * locator.
  * <p>
  * Only fails if specified and after having waited the given timeout.
  * </p>
  *
- * @param locator Locator to find the element in the current page.
- * @param timeout The time to wait before giving up the research.
- * @param fail Tells whether to fail if none of the locators is find before timeout.
+ * @param locator The locator to find the element in the current wrapped element. The
+ * locator must be relative to the current wrapped element.
+ * @param timeout The time to wait in seconds before giving up the search.
+ * @param fail Tells whether to fail if no element is located before timeout.
  *
  * @return The web element as {@link BrowserElement} or <code>null</code>
  * if no element was found before the timeout and asked not to fail.


### PR DESCRIPTION
### Issue

https://github.com/IBM/iTestCloud/issues/45

### Changes

- Modify Javadoc of `waitForElement` and `waitForElements`
- Sort the members

### Test

`com.ibm.itest.cloud.apsportal.demo.steps.StepA02_SanityTests`

### Result

```
The parameters properties file 'params/browser/chrome.properties' has been found.
The parameters properties file 'params/scenario.properties' has been found.
The parameters properties file 'params/environment/yp-prod-us.properties' has been found.
Read parameters while running scenario:
	- 'debug.dir' value=debug
	- 'stopOnFailure' value=true
	- 'verifyDependencies' value=false
	- 'applications' value=apsportal;https://dataplatform.cloud.ibm.com
	- 'environment' value=yp-prod-us
	- 'timeoutToOpenPage' value=30
	- 'browserKind' value=3
	- 'performanceEnabled' value=false
	- 'browserDriver' value=/Users/Shared/itestcloud/drivers/chromedriver
	- 'browserProfile' value=/Users/Shared/itestcloud/profiles/chrome
Starting ChromeDriver 109.0.5414.74 (e7c5703604daa9cc128ccf5a5d3e993513758913-refs/branch-heads/5414@{#1172}) on port 20427
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
Jan 29, 2023 4:27:58 P.M. org.openqa.selenium.devtools.CdpVersionFinder findNearestMatch
WARNING: Unable to find an exact match for CDP version 109, so returning the closest version found: 108
	- 'selenium.snapshots.dir' value=screenshots
	- 'testerUsername' value=DAP UXAuto
	- 'testerUserID' value=c3cvn9tx@ca.ibm.com
	- 'testerPassword' value=4*******
	- 'testerEmail' value=c3cvn9tx@ca.ibm.com
	- 'adminPassword' value=a*******
	- 'testUserAccount' value=DAP UXAuto
	- 'testUserOrganization' value=c3cvn9tx@ca.ibm.com
	- 'testUserSpace' value=dev
	- 'runDeepDiveTests' value=true
Selenium and Browser information:
	- Selenium Build info: version: '4.7.2', revision: '4d4020c3b7'
	- Google Chrome version: 109.0.5414.119

Starting execution of test case 'StepA02_SanityTests' at 16:27:59
=========================================================
	- 16:27:59: start test case 'test01_CreateProject'...

================================================================================
	  -> OK (in 1mn 1.335s)
	- 16:29:00: start test case 'test02_AddAssetToProject'...
	  -> Reset button element was unavailable. Therefore, no attempt was made to reset filter.
	  -> OK (in 18.195s)
	- 16:29:19: start test case 'test99_DeleteProject'...
	  -> Jobs did not exist in project 'sanity-test-project' and therefore, no attempt was made to delete any.
	  -> Active environment runtimes did not exist in project 'sanity-test-project' and therefore, no attempt was made to delete any.

================================================================================
	  -> OK (in 18.007s)

WARNING: No debug information written due argument debug=false
**********  SUMMARY OF FAILURES **********
Unknown failures : 0	Known failures : 0
```