### PR TITLE
Ignore comma in quotes when splitting params values.

### DIFF
--- a/projects/itest.cloud/src/itest/cloud/scenario/ScenarioRunner.java
+++ b/projects/itest.cloud/src/itest/cloud/scenario/ScenarioRunner.java
@@ -234,7 +234,7 @@ protected void initBulkParams() {
 	String parametersString = getParameterValue("params");
 
 	if(parametersString != null) {
-		String[] parameters = parametersString.split(",", -1 /*limit*/);
+		String[] parameters = parametersString.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1 /*limit*/);
 
 		for (String parameter : parameters) {
 			String[] parameterInfo = parameter.split("=");


### PR DESCRIPTION
### Issue

https://github.com/IBM/iTestCloud/issues/48

### Description

Ignore comma in quotes when splitting params values by using a regex in `split()`. The basic idea of that regex is to use positive lookahead, and split around a comma only if there are no double quotes or if there is an even number of double quotes ahead of it.

### Test result

After the fix, the test can be executed successfully.

```
The parameters properties file 'params/browser/chrome.properties' has been found.
The parameters properties file 'params/scenario.properties' has been found.
The parameters properties file 'params/secret.properties' has been found.
The parameters properties file 'params/environment/yp-prod-us.properties' has been found.
Read parameters while running scenario:
- 'debug.dir' value=debug
- 'params' value=param1=val1,param2="val21,val22",param3=val3
- 'stopOnFailure' value=true
- 'verifyDependencies' value=true
- 'verifyDependenciesOnly' value=true
- 'applications' value=apsportal;https://dataplatform.cloud.ibm.com/,bluemix;https://cloud.ibm.com/,openscale;https://aiopenscale.cloud.ibm.com/,watsonassistant;https://us-south.assistant.watson.cloud.ibm.com/,watsondiscovery;https://us-south.discovery.watson.cloud.ibm.com/
- 'environment' value=yp-prod-us
- 'timeoutToOpenPage' value=30
- 'browserKind' value=3
- 'browserDriver' value=/Users/Shared/itestcloud/drivers/chromedriver
- 'browserProfile' value=/Users/Shared/itestcloud/profiles/chrome
Starting ChromeDriver 112.0.5615.49 (bd2a7bcb881c11e8cfe3078709382934e3916914-refs/branch-heads/5615@{#936}) on port 55051
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
...
```

Signed-off-by: Hongyin Huo hhuo@ca.ibm.com